### PR TITLE
fixed mm browser chain issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@ethersproject/providers": "^5.4.5",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
+    "@metamask/detect-provider": "^1.2.0",
     "@mui/icons-material": "^5.5.0",
     "@mui/lab": "^5.0.0-alpha.72",
     "@mui/material": "^5.5.0",


### PR DESCRIPTION
The error occurred due to metamask browser not being able to inject the provider on page load. Resulting in a Nan chainId variable from the window.ethereum.chainId, when opening the app and navigating to the browser once you have connected once.

To fix the issue I introduced a new package @metamask/detect-provider to be able to detect a provider inside the metamask browser in case window.ethereum fails. The provider was also strapped as a failsafe option for the store's web3context provider.
This package also has the benefit of working with Safepal browser as well, which was not possible before this change - stated by a tester.

There were no devices that failed. Devices that were used to test with:
 - IPhone 8
 - IPhone X
 - IPhone 12
 - IPhone 13
 - samsung galaxy s21
 
Connection to other wallets during testing seemed unaffected.
 
 
 