### PR TITLE
add second FXS token, support for duplicate symbols

### DIFF
--- a/stores/constants/constants.js
+++ b/stores/constants/constants.js
@@ -89,6 +89,12 @@ export const BASE_ASSETS_WHITELIST = [
     symbol: "FXS",
   },
   {
+    id: "0x1a3acf6d19267e2d3e7f898f42803e90c9219062",
+    address: "0x1a3acf6d19267e2d3e7f898f42803e90c9219062",
+    chainId: "137",
+    symbol: "FXS",
+  },
+  {
     id: "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89",
     address: "0x45c32fa6df82ead1e2ef74d17b76547eddfaff89",
     chainId: "137",

--- a/stores/stableSwapStore.js
+++ b/stores/stableSwapStore.js
@@ -136,7 +136,8 @@ const removeDuplicate = (arr) => {
     if (item.symbol in assetIcons) {
       item.logoURI = '/images/assets/' + assetIcons[item.symbol]
     }
-    acc[item.symbol] = item;
+    // acc[item.symbol] = item;
+    acc[item.address.toLowerCase()] = item;
     return acc;
   }, {});
   return Object.values(assets);
@@ -1140,7 +1141,7 @@ class Store {
       baseAssets = baseAssets.filter((token) => {
         return BLACK_LIST_TOKENS.indexOf(token.address.toLowerCase()) === -1;
       });
-      let dupAssets = [];
+      /*let dupAssets = [];
       baseAssets.forEach((token, id) => {
         BASE_ASSETS_WHITELIST.forEach((wl) => {
           if (token.address.toLowerCase() !== wl.address.toLowerCase()
@@ -1150,7 +1151,7 @@ class Store {
         });
       });
       for (var i = dupAssets.length - 1; i >= 0; i--)
-        baseAssets.splice(dupAssets[i], 1);
+        baseAssets.splice(dupAssets[i], 1);*/
 
       // console.log("baseAssets",removeDuplicate([...baseAssets, ...localBaseAssets]))
       return removeDuplicate([...baseAssets, ...localBaseAssets]);


### PR DESCRIPTION
To support two whitelisted tokens with same symbol, I had to turn off the check for duplicate tokens through the symbol.